### PR TITLE
Remove file output stubs and simplify engine init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,7 +272,7 @@ case WM_APP_DEVICE: {
         if (new_idx != g_dev_index){
             g_dev_index = new_idx;
             // Re-init the engine on the new device
-            tts_init(g_eng, g_dev_index, g_to_file, g_wavpath.c_str());
+            tts_init(g_eng, g_dev_index);
         }
         // reflect back to GUI so the combo shows the actual device
         if (HWND dlg = gui_get_main_hwnd()){
@@ -336,7 +336,6 @@ case WM_APP_TTS_TEXT_START:
 
 case WM_APP_TTS_TEXT_DONE: {
     if (g_inflight_local > 0) g_inflight_local--;
-    tts_file_flush(g_eng); // (no-op for device mode)
     if (g_eng.inflight.load(std::memory_order_relaxed) == 0) {
         kick_if_idle();
         if (g_eng.inflight.load(std::memory_order_relaxed) == 0 && g_q.empty()) {
@@ -466,7 +465,7 @@ log_set_verbose(g_verbose);
         }
     }
 
-    if (!tts_init(g_eng, g_dev_index, g_to_file, g_to_file ? g_wavpath.c_str() : nullptr)){
+    if (!tts_init(g_eng, g_dev_index)){
         MessageBeep(MB_ICONERROR);
         return 2;
     }

--- a/src/tts_engine.cpp
+++ b/src/tts_engine.cpp
@@ -124,11 +124,8 @@ struct BufSinkW : public ITTSBufNotifySink, public ITTSNotifySink {
 };
 
 // -----------------------------------------------------------
-// Voice selection + audio binding (WAV capture disabled)
-static bool select_voice_and_audio(Engine& e, int device_index, bool to_file, const wchar_t* wav_path){
-    // Remember flags but ignore file capture
-    e.to_file  = false;      // hard-disable WAV recording
-    e.wav_path = wav_path ? wav_path : L"";
+// Voice selection + audio binding
+static bool select_voice_and_audio(Engine& e, int device_index){
 
     ITTSFindW* findW = nullptr;
     HRESULT hr = CoCreateInstance(CLSID_TTSEnumerator, nullptr, CLSCTX_ALL, IID_ITTSFindW, (void**)&findW);
@@ -173,19 +170,15 @@ static bool select_voice_and_audio(Engine& e, int device_index, bool to_file, co
     // Probe PosnGet
     QWORD q=0; e.has_posn = SUCCEEDED(e.cw->PosnGet(&q));
 
-    // If user asked for --file, tell them it's disabled (once)
-    if (to_file && wav_path && *wav_path) {
-        dbg(L"[tts] WAV capture disabled; using device output only.");
-    }
     return true;
 }
 
 // -----------------------------------------------------------
 // API
-bool tts_init(Engine& e, int device_index, bool to_file, const wchar_t* wav_path){
+bool tts_init(Engine& e, int device_index){
     tts_shutdown(e);
     CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    if (!select_voice_and_audio(e, device_index, to_file, wav_path)) return false;
+    if (!select_voice_and_audio(e, device_index)) return false;
     dbg(L"[tts] init: PosnGet=%s", e.has_posn ? L"yes" : L"no");
     return true;
 }

--- a/src/tts_engine.hpp
+++ b/src/tts_engine.hpp
@@ -30,10 +30,6 @@ struct Engine {
 
     // PosnGet availability
     bool             has_posn = false;
-
-    // Flags/fields kept for compatibility (WAV disabled; these are ignored)
-    bool             to_file   = false;
-    std::wstring     wav_path;
 };
 
 // App messages (match your main.cpp; re-defining to the same value is OK)
@@ -44,7 +40,7 @@ struct Engine {
 #define WM_APP_TTS_TEXT_DONE     (WM_APP + 7)
 
 // Init / shutdown
-bool tts_init   (Engine& e, int device_index /* -1 = default mapper */, bool to_file = false, const wchar_t* wav_path = nullptr);
+bool tts_init   (Engine& e, int device_index /* -1 = default mapper */);
 void tts_shutdown(Engine& e);
 
 // Where to post WM_APP_* messages
@@ -72,10 +68,6 @@ std::wstring tts_vendor_prefix_from_ui();
 // PosnGet support
 bool tts_supports_posn(Engine& e);
 int  tts_posn_get     (Engine& e, DWORD* pos_out /* low 32 bits ok */);
-
-// File-mode compatibility stubs (no-ops now)
-inline void tts_prepare_next_file_chunk(Engine&){ /* WAV capture disabled */ }
-inline void tts_file_flush(Engine&){ /* WAV capture disabled */ }
 
 
 // Prefer vendor sticky tags for speed/pitch (FlexTalk honors these best)


### PR DESCRIPTION
## Summary
- Drop unused file output fields and helpers
- Simplify `tts_init` and voice setup to only take device index
- Remove `tts_file_flush` call and file-related stubs

## Testing
- `make -f Makefile.mingw clean`
- `make -f Makefile.mingw` *(fails: i686-w64-mingw32-g++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb3f99ae0833380e7ed56e592f62d