### PR TITLE
Remove obsolete tts_file_flush call

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,7 +336,6 @@ case WM_APP_TTS_TEXT_START:
 
 case WM_APP_TTS_TEXT_DONE: {
     if (g_inflight_local > 0) g_inflight_local--;
-    tts_file_flush(g_eng); // (no-op for device mode)
     if (g_eng.inflight.load(std::memory_order_relaxed) == 0) {
         kick_if_idle();
         if (g_eng.inflight.load(std::memory_order_relaxed) == 0 && g_q.empty()) {


### PR DESCRIPTION
## Summary
- Remove redundant `tts_file_flush` invocation after TTS text completion

## Testing
- `make -f Makefile.mingw` *(fails: i686-w64-mingw32-g++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb40e96cc8333b54800a20ca96023