### PR TITLE
Remove WAV capture references from help text

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -6,7 +6,6 @@
 std::wstring get_help_text_w(){ // central source of truth
     // (Keep this short and accurate; main.cpp owns behavior.)
     // Current flags are based on the code in main/net_server/tts_engine.
-    // WAV capture is disabled in the engine by design.
     const wchar_t* lines[] = {
         L"Usage: nettts_gui.exe [--gui|--headless] [--verbose]",
         L"                       [--host HOST] [--port N] [--devnum N]",
@@ -38,7 +37,6 @@ std::wstring get_help_text_w(){ // central source of truth
         L"  [[pause 500]]        In-band pause directive (transforms to \\!sf500 plus \\!br)",
         L"",
         L"Notes:",
-        L"  • WAV capture is disabled; audio goes to the selected device.",
         L"  • In VOX modes, final cadence adds a ~500ms pause and a boundary.",
         nullptr
     };


### PR DESCRIPTION
## Summary
- Drop internal comment about disabled WAV capture
- Remove WAV capture note from help text

## Testing
- `make -f Makefile.mingw -j"$(nproc)"` *(fails: i686-w64-mingw32-g++: not found)*
- `apt-get install -y make mingw-w64 g++-mingw-w64-i686` *(fails: Unable to locate package mingw-w64)*

------
https://chatgpt.com/codex/tasks/task_e_68beb411b3388333920684fea0d5ca25