### PR TITLE
Remove g_show_window variable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,6 @@
 
 // ------------------------------------------------------------------
 // CLI state
-static bool         g_show_window   = false;
 static bool         g_headless      = false;
 static bool         g_verbose       = false;
 static std::wstring g_host          = L"127.0.0.1";


### PR DESCRIPTION
## Summary
- remove unused g_show_window variable from main.cpp CLI state

## Testing
- `make -f Makefile.mingw` *(fails: i686-w64-mingw32-g++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb417d7e08333a1a72be2b86bb582