### PR TITLE
Consolidate GUI helper declarations

### DIFF
--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -15,11 +15,7 @@
 bool show_help_dialog(HINSTANCE hInst, HWND parent);
 HWND create_main_dialog(HINSTANCE hInst, HWND parent = nullptr);
 
-HWND gui_get_main_hwnd();
-void gui_notify_tts_state(bool busy);
-void gui_set_app_hwnd(HWND hwnd);
-
-
 // ---- GUI helpers (implemented in gui.cpp) ----
 HWND gui_get_main_hwnd();            // returns the dialog HWND if created, else nullptr
 void gui_notify_tts_state(bool busy); // one-liner: post WM_APP_TTS_STATE to the dialog
+void gui_set_app_hwnd(HWND hwnd);


### PR DESCRIPTION
## Summary
- Remove duplicate `gui_get_main_hwnd` and `gui_notify_tts_state` declarations
- Group GUI helper prototypes together and ensure file ends with newline

## Testing
- `make -f Makefile.mingw -j"$(nproc)"` *(fails: i686-w64-mingw32-g++ not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `apt-get install -y make mingw-w64 g++-mingw-w64-i686` *(fails: unable to locate packages)*

------
https://chatgpt.com/codex/tasks/task_e_68beb4198fb08333b49079346c0f96cb