### PR TITLE
Fix WM_HSCROLL switch fall-through in GUI

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -93,23 +93,25 @@ static INT_PTR CALLBACK MainDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
     }
 
     case WM_HSCROLL:{
-    const HWND hVol   = GetDlgItem(hDlg, IDC_VOL_SLIDER);
-    const HWND hRate  = GetDlgItem(hDlg, IDC_RATE_SLIDER);
-    const HWND hPitch = GetDlgItem(hDlg, IDC_PITCH_SLIDER);
+        const HWND hVol   = GetDlgItem(hDlg, IDC_VOL_SLIDER);
+        const HWND hRate  = GetDlgItem(hDlg, IDC_RATE_SLIDER);
+        const HWND hPitch = GetDlgItem(hDlg, IDC_PITCH_SLIDER);
 
-    const int vol   = (int)SendMessageW(hVol,   TBM_GETPOS, 0, 0);   // 0..100
-    const int rate  = (int)SendMessageW(hRate,  TBM_GETPOS, 0, 0);   // 30..200
-    const int pitch = (int)SendMessageW(hPitch, TBM_GETPOS, 0, 0);   // 50..150
+        const int vol   = (int)SendMessageW(hVol,   TBM_GETPOS, 0, 0);   // 0..100
+        const int rate  = (int)SendMessageW(hRate,  TBM_GETPOS, 0, 0);   // 30..200
+        const int pitch = (int)SendMessageW(hPitch, TBM_GETPOS, 0, 0);   // 50..150
 
-    // Update the numeric labels:
-    wchar_t b[32];
-    _snwprintf(b, 31, L"%d%%", vol);        SetDlgItemTextW(hDlg, IDC_VOL_VAL,  b);
-    _snwprintf(b, 31, L"%.2f", rate/100.0); SetDlgItemTextW(hDlg, IDC_RATE_VAL, b);
-    _snwprintf(b, 31, L"%.2f", pitch/100.0);SetDlgItemTextW(hDlg, IDC_PITCH_VAL,b);
+        // Update the numeric labels:
+        wchar_t b[32];
+        _snwprintf(b, 31, L"%d%%", vol);        SetDlgItemTextW(hDlg, IDC_VOL_VAL,  b);
+        _snwprintf(b, 31, L"%.2f", rate/100.0); SetDlgItemTextW(hDlg, IDC_RATE_VAL, b);
+        _snwprintf(b, 31, L"%.2f", pitch/100.0);SetDlgItemTextW(hDlg, IDC_PITCH_VAL,b);
 
-    if (s_appWnd){
-        auto* p = new GuiAttrs{ vol, rate, pitch };
-        PostMessageW(s_appWnd, WM_APP_ATTRS, 0, (LPARAM)p);
+        if (s_appWnd){
+            auto* p = new GuiAttrs{ vol, rate, pitch };
+            PostMessageW(s_appWnd, WM_APP_ATTRS, 0, (LPARAM)p);
+        }
+        return TRUE;
     }
 
     case WM_APP_ENUMDEV:{
@@ -133,11 +135,7 @@ static INT_PTR CALLBACK MainDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
         }
         return TRUE;
     }
-    return TRUE;
-}
-
-
-case WM_APP_SET_SERVER_FIELDS: {
+    case WM_APP_SET_SERVER_FIELDS: {
     auto* f = (GuiServerFields*)lParam;
     if (f){
         SetDlgItemTextW(hDlg, IDC_EDIT_HOST, f->host);


### PR DESCRIPTION
## Summary
- prevent `WM_APP_ENUMDEV` case from being nested inside `WM_HSCROLL`

## Testing
- `make -f Makefile.mingw -j"$(nproc)"` *(fails: i686-w64-mingw32-g++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef3527c308333aeba4e6af8d19311