### PR TITLE
Use AudioStop for GUI speak-state

### DIFF
--- a/src/ipc.hpp
+++ b/src/ipc.hpp
@@ -54,6 +54,10 @@
 #define WM_APP_PROSODY_STATE (WM_APP + 20)  // main → GUI: wParam: mode
 #endif
 
+#ifndef WM_APP_TTS_AUDIO_DONE
+#define WM_APP_TTS_AUDIO_DONE (WM_APP + 21)  // engine → main: audio buffer drained
+#endif
+
 // ---- POD payloads ----
 struct GuiAttrs { int vol_percent; int rate_percent; int pitch_percent; };
 struct GuiDeviceSel { int index; /* -1 = default */ };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,9 +342,14 @@ case WM_APP_TTS_TEXT_DONE: {
     if (g_inflight_local > 0) g_inflight_local--;
     if (g_eng.inflight.load(std::memory_order_relaxed) == 0) {
         kick_if_idle();
-        if (g_eng.inflight.load(std::memory_order_relaxed) == 0 && g_q.empty()) {
-            gui_notify_tts_state(false);  // <— GUI button → "Speak"
-        }
+    }
+    return 0;
+}
+
+case WM_APP_TTS_AUDIO_DONE: {
+    if (g_eng.inflight.load(std::memory_order_relaxed) == 0 && g_q.empty()) {
+        gui_notify_tts_state(false);
+        if (g_headless) dprintf("[tts] audio done");
     }
     return 0;
 }

--- a/src/tts_engine.cpp
+++ b/src/tts_engine.cpp
@@ -119,7 +119,13 @@ struct BufSinkW : public ITTSBufNotifySink, public ITTSNotifySink {
     // ---- ITTSNotifySink (QWORD tick times) ----
     STDMETHOD(AttribChanged)(DWORD)        { return S_OK; }
     STDMETHOD(AudioStart)(QWORD)           { return S_OK; }
-    STDMETHOD(AudioStop)(QWORD)            { return S_OK; }
+    STDMETHOD(AudioStop)(QWORD) {
+        if (m_eng) {
+            dbg(L"[tts] audio stop");
+            if (m_eng->notify_hwnd) PostMessageW(m_eng->notify_hwnd, WM_APP_TTS_AUDIO_DONE, 0, 0);
+        }
+        return S_OK;
+    }
     STDMETHOD(Visual)(QWORD, WCHAR, WCHAR, DWORD, PTTSMOUTH) { return S_OK; }
 };
 

--- a/src/tts_engine.hpp
+++ b/src/tts_engine.hpp
@@ -38,6 +38,7 @@ struct Engine {
 #endif
 #define WM_APP_TTS_TEXT_START    (WM_APP + 8)
 #define WM_APP_TTS_TEXT_DONE     (WM_APP + 7)
+#define WM_APP_TTS_AUDIO_DONE    (WM_APP + 21)
 
 // Init / shutdown
 bool tts_init   (Engine& e, int device_index /* -1 = default mapper */);


### PR DESCRIPTION
## Summary
- Add new `WM_APP_TTS_AUDIO_DONE` message and emit it when the engine finishes playing audio
- Drive the Speak/Stop button off `AudioStop` instead of `TextDataDone`, preserving existing inflight logic
- Log audio completion so the runtime log reflects when playback actually ends

## Testing
- `make -f Makefile.mingw` *(fails: i686-w64-mingw32-g++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd88c610083339b03e614e3063a67