### PR TITLE
Use SpeedSet for rate control

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -74,9 +74,9 @@ static INT_PTR CALLBACK MainDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
         SetDlgItemTextW(hDlg, IDC_BTN_SERVER, L"Start Server");
         SetDlgItemTextW(hDlg, IDC_BTN_SPEAK,  L"Speak");
 
-    // Vol 0..100, Rate 30..200 (100=1.00), Pitch 50..150 (100=1.00)
+    // Vol 0..100, Rate 0..100, Pitch 50..150 (100=1.00)
     SendDlgItemMessageW(hDlg, IDC_VOL_SLIDER,  TBM_SETRANGE, TRUE, MAKELONG(0, 100));
-    SendDlgItemMessageW(hDlg, IDC_RATE_SLIDER, TBM_SETRANGE, TRUE, MAKELONG(30, 200));
+    SendDlgItemMessageW(hDlg, IDC_RATE_SLIDER, TBM_SETRANGE, TRUE, MAKELONG(0, 100));
     SendDlgItemMessageW(hDlg, IDC_PITCH_SLIDER,TBM_SETRANGE, TRUE, MAKELONG(50, 150));
 
     SendDlgItemMessageW(hDlg, IDC_VOL_SLIDER,  TBM_SETPOS, TRUE, 100);
@@ -113,13 +113,13 @@ static INT_PTR CALLBACK MainDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
         const HWND hPitch = GetDlgItem(hDlg, IDC_PITCH_SLIDER);
 
         const int vol   = (int)SendMessageW(hVol,   TBM_GETPOS, 0, 0);   // 0..100
-        const int rate  = (int)SendMessageW(hRate,  TBM_GETPOS, 0, 0);   // 30..200
+        const int rate  = (int)SendMessageW(hRate,  TBM_GETPOS, 0, 0);   // 0..100
         const int pitch = (int)SendMessageW(hPitch, TBM_GETPOS, 0, 0);   // 50..150
 
         // Update the numeric labels:
         wchar_t b[32];
         _snwprintf(b, 31, L"%d%%", vol);        SetDlgItemTextW(hDlg, IDC_VOL_VAL,  b);
-        _snwprintf(b, 31, L"%.2f", rate/100.0); SetDlgItemTextW(hDlg, IDC_RATE_VAL, b);
+        _snwprintf(b, 31, L"%d%%", rate);       SetDlgItemTextW(hDlg, IDC_RATE_VAL, b);
         _snwprintf(b, 31, L"%.2f", pitch/100.0);SetDlgItemTextW(hDlg, IDC_PITCH_VAL,b);
 
         if (s_appWnd){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,7 @@ static void expand_inline_pauses_and_enqueue(const std::string& line){
     }
 }
 
-// Map leading “/rate N” and “/pitch N” to vendor tags (non-sticky)
+// Map leading “/rate N” to SpeedSet and “/pitch N” to vendor tags (non-sticky)
 static bool maybe_handle_inline_cmds(const std::string& line){
     auto is_space = [](char c){ return !!isspace((unsigned char)c); };
     size_t i=0, n=line.size(); while (i<n && is_space(line[i])) ++i;
@@ -97,9 +97,8 @@ static bool maybe_handle_inline_cmds(const std::string& line){
         size_t p = rest(j); int val=0; bool have=false;
         while (p<n && isdigit((unsigned char)line[p])) { have=true; val = val*10 + (line[p]-'0'); ++p; }
         if (have){
-            double scale = 2.0 - (1.9 * (std::min(std::max(val,0),100) / 100.0));
-            wchar_t t[64]; _snwprintf(t,63,L" \\!R%.2f ", scale);
-            g_q.push_back({ t }); g_q.push_back({ L" \\!br " });
+            val = std::min(std::max(val,0),100);
+            tts_set_rate_percent_ui(g_eng, val);
             return true;
         }
     } else if (kw=="pitch"){
@@ -254,7 +253,7 @@ case WM_APP_ATTRS:{
     auto* p = (GuiAttrs*)l;
     if (p){
         tts_set_volume_percent(g_eng,p->vol_percent);
-        tts_set_rate_percent_ui(p->rate_percent);
+        tts_set_rate_percent_ui(g_eng, p->rate_percent);
         tts_set_pitch_percent_ui(p->pitch_percent);
         delete p;
     }

--- a/src/tts_engine.cpp
+++ b/src/tts_engine.cpp
@@ -11,14 +11,15 @@
 #endif
 
 // Stashed UI values (lazy apply on next utterance)
-static std::atomic<int> g_ui_rate_pct{100};   // 30..200 (100 = 1.00)
 static std::atomic<int> g_ui_pitch_pct{100};  // 50..150 (100 = 1.00)
 
 
 
-void tts_set_rate_percent_ui(int pct){
-    if (pct < 30) pct = 30; if (pct > 200) pct = 200;
-    g_ui_rate_pct.store(pct, std::memory_order_relaxed);
+void tts_set_rate_percent_ui(Engine& e, int pct){
+    if (!e.attrsW) return;
+    if (pct < 0) pct = 0; if (pct > 100) pct = 100;
+    DWORD v = (DWORD)((pct * 65535) / 100);
+    (void)e.attrsW->SpeedSet(v);
 }
 void tts_set_pitch_percent_ui(int pct){
     if (pct < 50) pct = 50; if (pct > 150) pct = 150;
@@ -35,18 +36,11 @@ void tts_set_volume_percent(Engine& e, int pct){
 
 // Build a tag prefix to prepend at speak time
 std::wstring tts_vendor_prefix_from_ui(){
-    const int r = g_ui_rate_pct.load(std::memory_order_relaxed);
     const int p = g_ui_pitch_pct.load(std::memory_order_relaxed);
-    if (r == 100 && p == 100) return L"";
+    if (p == 100) return L"";
     std::wstring out;
-    if (r != 100){
-        wchar_t buf[32]; _snwprintf(buf, 31, L" \\!R%.2f ", r / 100.0);
-        out += buf;
-    }
-    if (p != 100){
-        wchar_t buf[32]; _snwprintf(buf, 31, L" \\!%%%.2f ", p / 100.0);
-        out += buf;
-    }
+    wchar_t buf[32]; _snwprintf(buf, 31, L" \\!%%%.2f ", p / 100.0);
+    out += buf;
     return out;
 }
 

--- a/src/tts_engine.hpp
+++ b/src/tts_engine.hpp
@@ -55,11 +55,11 @@ inline void tts_audio_reset (Engine& e){ if (e.cw) e.cw->AudioReset(); }
 inline void tts_audio_pause (Engine& e){ if (e.cw) e.cw->AudioPause(); }
 inline void tts_audio_resume(Engine& e){ if (e.cw) e.cw->AudioResume(); }
 
-// UI → engine (instant): volume
+// UI → engine (instant)
 void tts_set_volume_percent(Engine& e, int pct);
+void tts_set_rate_percent_ui(Engine& e, int pct);
 
 // UI → stash for next utterance (no immediate engine I/O)
-void tts_set_rate_percent_ui(int pct);
 void tts_set_pitch_percent_ui(int pct);
 
 // Build vendor tag prefix for next utterance ("" if defaults)


### PR DESCRIPTION
## Summary
- Drive rate changes through `ITTSAttributesW::SpeedSet` and normalize slider/CLI to 0–100
- Drop rate tag emission while retaining pitch tag support
- Update `/rate` command and GUI slider to use new instant rate control

## Testing
- `make -f Makefile.mingw`

------
https://chatgpt.com/codex/tasks/task_e_68c070806b048333852c388a5e98254a