### PR TITLE
Restore Speak button reset fallback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,6 +380,11 @@ case WM_APP_TTS_TEXT_DONE: {
     if (g_inflight_local > 0) g_inflight_local--;
     if (g_eng.inflight.load(std::memory_order_relaxed) == 0) {
         kick_if_idle();
+        // Fallback: if nothing else was queued, make sure the GUI flips back to
+        // "Speak" even if the audio sink never sent WM_APP_TTS_AUDIO_DONE.
+        if (g_eng.inflight.load(std::memory_order_relaxed) == 0 && g_q.empty()) {
+            gui_notify_tts_state(false);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- restore the WM_APP_TTS_TEXT_DONE fallback that resets the Speak button when no more audio is pending
- add a comment explaining the fallback to guard against missing WM_APP_TTS_AUDIO_DONE notifications

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd27a3b3188333990f3f226ca6beed