### PR TITLE
Ensure main dialog shows taskbar icon

### DIFF
--- a/nettts.rc
+++ b/nettts.rc
@@ -60,6 +60,7 @@ END
 // A compact, clean layout. Font matches the Help dialog ("MS Shell Dlg", 8).
 IDD_MAIN DIALOGEX 0, 0, 420, 405
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX
+EXSTYLE WS_EX_APPWINDOW
 CAPTION "NetTTS"
 FONT 8, "MS Shell Dlg"
 BEGIN


### PR DESCRIPTION
## Summary
- add WS_EX_APPWINDOW extended style to the main dialog template so it appears on the taskbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd357ffbc48333bc4f3afe8c06d1db