### PR TITLE
Grant contents write permission for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Build and Release
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- add contents write permission to the release workflow so GitHub can publish releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd81f4db84833392dd2f20ea13dab0