### PR TITLE
Factor reusable Win32 scaffolding

### DIFF
--- a/src/app_bootstrap.cpp
+++ b/src/app_bootstrap.cpp
@@ -1,0 +1,61 @@
+#include "app_bootstrap.hpp"
+
+#include <commctrl.h>
+
+bool app_init_common_controls(){
+    INITCOMMONCONTROLSEX icc{};
+    icc.dwSize = sizeof(icc);
+    icc.dwICC  = ICC_WIN95_CLASSES | ICC_LINK_CLASS;
+    if (InitCommonControlsEx(&icc)){
+        return true;
+    }
+    icc.dwICC = ICC_WIN95_CLASSES;
+    return InitCommonControlsEx(&icc) != FALSE;
+}
+
+ATOM app_register_window_class(const AppWindowClass& info){
+    WNDCLASSEXW wc{};
+    wc.cbSize        = sizeof(wc);
+    wc.style         = info.style;
+    wc.lpfnWndProc   = info.wnd_proc;
+    wc.cbClsExtra    = 0;
+    wc.cbWndExtra    = 0;
+    wc.hInstance     = info.instance;
+    wc.hIcon         = info.icon;
+    wc.hCursor       = info.cursor ? info.cursor : LoadCursor(nullptr, IDC_ARROW);
+    wc.hbrBackground = nullptr;
+    wc.lpszMenuName  = nullptr;
+    wc.lpszClassName = info.class_name;
+    wc.hIconSm       = info.icon_small;
+    return RegisterClassExW(&wc);
+}
+
+HWND app_create_hidden_window(const AppWindowCreate& info){
+    return CreateWindowExW(info.ex_style,
+                           info.class_name,
+                           info.window_name,
+                           info.style,
+                           info.x,
+                           info.y,
+                           info.width,
+                           info.height,
+                           info.parent,
+                           info.menu,
+                           info.instance,
+                           info.param);
+}
+
+int app_run_message_loop(){
+    MSG msg;
+    while (true){
+        BOOL r = GetMessageW(&msg, nullptr, 0, 0);
+        if (r == 0){
+            return static_cast<int>(msg.wParam);
+        }
+        if (r == -1){
+            return -1;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+}

--- a/src/app_bootstrap.hpp
+++ b/src/app_bootstrap.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <windows.h>
+
+struct AppWindowClass {
+    UINT     style;
+    LPCWSTR  class_name;
+    WNDPROC  wnd_proc;
+    HINSTANCE instance;
+    HCURSOR  cursor;
+    HICON    icon;
+    HICON    icon_small;
+};
+
+struct AppWindowCreate {
+    DWORD    ex_style;
+    LPCWSTR  class_name;
+    LPCWSTR  window_name;
+    DWORD    style;
+    int      x;
+    int      y;
+    int      width;
+    int      height;
+    HWND     parent;
+    HMENU    menu;
+    HINSTANCE instance;
+    LPVOID   param;
+};
+
+bool app_init_common_controls();
+
+ATOM app_register_window_class(const AppWindowClass& info);
+
+HWND app_create_hidden_window(const AppWindowCreate& info);
+
+int app_run_message_loop();

--- a/src/app_cli.cpp
+++ b/src/app_cli.cpp
@@ -1,0 +1,79 @@
+#include "app_cli.hpp"
+
+#include <shellapi.h>
+#include <windows.h>
+#include <cstdlib>
+
+#include "log.hpp"
+
+void app_cli_ensure_console(AppCliContext& ctx){
+    if (!ctx.console_attached){
+        log_attach_console();
+        ctx.console_attached = true;
+        ctx.result.console_attached = true;
+    }
+}
+
+AppCliResult parse_app_cli(const AppCliHooks* hooks){
+    AppCliResult result{};
+    result.headless        = false;
+    result.run_server      = false;
+    result.help_requested  = false;
+    result.verbose_logging = false;
+    result.exit_requested  = false;
+    result.exit_code       = 0;
+    result.console_attached= false;
+    result.host            = L"127.0.0.1";
+    result.port            = 5555;
+    result.device_index    = -1;
+    result.posn_poll_ms    = 0;
+    result.has_log_path    = false;
+    result.log_path.clear();
+
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv) return result;
+
+    bool console_attached = false;
+    AppCliContext ctx{result, console_attached};
+
+    for (int i = 1; i < argc; ++i){
+        std::wstring arg = argv[i];
+
+        if (arg == L"--help" || arg == L"-h" || arg == L"/?"){
+            result.help_requested = true;
+        } else if (arg == L"--headless" || arg == L"--verbose"){
+            result.headless = true;
+            result.verbose_logging = true;
+        } else if (arg == L"--runserver" || arg == L"--startserver"){
+            result.run_server = true;
+        } else if (arg == L"--log" && i + 1 < argc){
+            result.has_log_path = true;
+            result.log_path = argv[++i];
+        } else if (arg == L"--host" && i + 1 < argc){
+            result.host = argv[++i];
+        } else if (arg == L"--port" && i + 1 < argc){
+            result.port = _wtoi(argv[++i]);
+        } else if (arg == L"--devnum" && i + 1 < argc){
+            result.device_index = _wtoi(argv[++i]);
+        } else if (arg == L"--posn-ms" && i + 1 < argc){
+            result.posn_poll_ms = _wtoi(argv[++i]);
+        } else if (hooks && hooks->handle_option &&
+                   hooks->handle_option(arg, i, argc, argv, ctx, hooks->user_data)){
+            if (result.exit_requested) break;
+        }
+    }
+
+    if (result.headless){
+        result.verbose_logging = true;
+    }
+
+    if ((result.headless || result.help_requested) && !console_attached){
+        app_cli_ensure_console(ctx);
+    }
+
+    LocalFree(argv);
+
+    result.console_attached = console_attached;
+    return result;
+}

--- a/src/app_cli.hpp
+++ b/src/app_cli.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <windows.h>
+
+struct AppCliResult {
+    bool headless;
+    bool run_server;
+    bool help_requested;
+    bool verbose_logging;
+    bool exit_requested;
+    int  exit_code;
+    bool console_attached;
+
+    std::wstring host;
+    int          port;
+    int          device_index;
+    int          posn_poll_ms;
+
+    std::wstring log_path;
+    bool         has_log_path;
+};
+
+struct AppCliContext {
+    AppCliResult& result;
+    bool&         console_attached;
+};
+
+struct AppCliHooks {
+    bool (*handle_option)(const std::wstring& option,
+                          int&                index,
+                          int                 argc,
+                          wchar_t**           argv,
+                          AppCliContext&      ctx,
+                          void*               user_data);
+    void* user_data;
+};
+
+void app_cli_ensure_console(AppCliContext& ctx);
+
+AppCliResult parse_app_cli(const AppCliHooks* hooks = nullptr);

--- a/src/app_window.cpp
+++ b/src/app_window.cpp
@@ -1,0 +1,47 @@
+#include "app_window.hpp"
+
+AppWindowHandled handle_common_window_messages(HWND hwnd,
+                                               UINT message,
+                                               WPARAM wparam,
+                                               LPARAM /*lparam*/,
+                                               const AppWindowCallbacks* callbacks){
+    AppWindowHandled handled{false, 0};
+
+    switch (message){
+    case WM_TIMER:
+        if (callbacks && callbacks->on_timer){
+            if (callbacks->on_timer(hwnd, static_cast<UINT_PTR>(wparam), callbacks->user_data)){
+                handled.handled = true;
+                handled.result  = 0;
+            }
+        }
+        break;
+
+    case WM_CLOSE:
+        if (callbacks && callbacks->on_close){
+            if (callbacks->on_close(hwnd, callbacks->user_data)){
+                handled.handled = true;
+                handled.result  = 0;
+                break;
+            }
+        }
+        DestroyWindow(hwnd);
+        handled.handled = true;
+        handled.result  = 0;
+        break;
+
+    case WM_DESTROY:
+        if (callbacks && callbacks->on_destroy){
+            callbacks->on_destroy(hwnd, callbacks->user_data);
+        }
+        PostQuitMessage(0);
+        handled.handled = true;
+        handled.result  = 0;
+        break;
+
+    default:
+        break;
+    }
+
+    return handled;
+}

--- a/src/app_window.hpp
+++ b/src/app_window.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <windows.h>
+
+struct AppWindowCallbacks {
+    bool (*on_timer)(HWND hwnd, UINT_PTR timer_id, void* user_data);
+    bool (*on_close)(HWND hwnd, void* user_data);
+    void (*on_destroy)(HWND hwnd, void* user_data);
+    void* user_data;
+};
+
+struct AppWindowHandled {
+    bool    handled;
+    LRESULT result;
+};
+
+AppWindowHandled handle_common_window_messages(HWND hwnd,
+                                               UINT message,
+                                               WPARAM wparam,
+                                               LPARAM lparam,
+                                               const AppWindowCallbacks* callbacks = nullptr);


### PR DESCRIPTION
## Summary
- add an `app_cli` helper that gathers default NetTTS arguments, attaches the console when needed, and lets the executable register custom switches
- introduce `app_bootstrap` to wrap common Win32 initialization, window class registration, window creation, and the message loop
- provide an `app_window` helper so the main window procedure can delegate generic timers and shutdown handling while keeping app-specific messages in place
- refactor `main.cpp` to consume the new helpers, delegate WM_TIMER/WM_DESTROY work, and streamline the entrypoint

## Testing
- make -f Makefile.mingw -j2 *(fails: i686-w64-mingw32-g++ not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd99ead9348333ace173ea7c4cc92c