### PR TITLE
Handle stale status server thread handle

### DIFF
--- a/src/net_server.cpp
+++ b/src/net_server.cpp
@@ -303,8 +303,18 @@ void server_stop(){
 bool status_server_start(const std::wstring& host, int port){
     if (g_status_thread){
         DWORD wait_result = WaitForSingleObject(g_status_thread, 0);
-        if (wait_result == WAIT_TIMEOUT || status_server_is_running()){
-            return true; // already running
+        if (wait_result == WAIT_TIMEOUT){
+            if (status_server_is_running()){
+                return true; // already running
+            }
+
+            // Thread handle is alive but not reporting a running server; try to stop it.
+            dprintf("[status] stale status thread detected; restarting");
+            g_status_stop = 1;
+            if(g_status_listen!=INVALID_SOCKET){ shutdown(g_status_listen, SD_BOTH); }
+            WaitForSingleObject(g_status_thread, 2000);
+        } else if (status_server_is_running()){
+            return true; // thread completed but server still marked running (should be rare)
         }
 
         CloseHandle(g_status_thread);


### PR DESCRIPTION
## Summary
- ensure status server start checks the running state and thread liveness before reusing the listener
- close stale status server thread handles so a new listener can be created

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a68f253dc8333a1fd208e5265d1df)