### PR TITLE
Document FlexTalk sink override

### DIFF
--- a/docs/winetricks.md
+++ b/docs/winetricks.md
@@ -49,6 +49,15 @@ After a successful run you can expect:
   - `nettts-daemon.sh` – start/stop the headless TCP server, send quick lines with `speak`, and refresh the captured device list
   - `nettts-gui.sh` – launch the GUI build inside the managed prefix
   - `flextalk-controlpanel.sh` – open the FlexTalk control panel (`C:\windows\system32\flextalk.cpl`)
+- To steer the FlexTalk control panel to a specific PulseAudio sink (handy when the default is a null sink for OBS monitoring),
+  export the sink variables before launching it, for example:
+
+  ```bash
+  # Use the ATR2USB stereo device instead of the system default
+  export FLEXSINK="alsa_output.usb-UC_MIC_ATR2USB-00.analog-stereo"
+  export PULSE_SINK="$FLEXSINK"
+  "$BASE_DIR/bin/flextalk-controlpanel.sh"
+  ```
 - Configuration and state in `<root>/etc/`:
   - `nettts-daemon.conf` – TCP host/port, VOX mode, and output device selection (VOX enabled and device `-1` by default)
   - Logs written by `nettts_gui.exe --log` live alongside the executable (`<root>/wineprefix/drive_c/nettts/nettts.log`, Windows path `C:\\nettts\\nettts.log`)

--- a/scripts/winetricks/setup_nettts_prefix.sh
+++ b/scripts/winetricks/setup_nettts_prefix.sh
@@ -649,6 +649,10 @@ set -euo pipefail
 
 unset LD_PRELOAD LD_LIBRARY_PATH GTK3_MODULES GTK_MODULES GTK_PATH QT_PLUGIN_PATH QT_QPA_PLATFORMTHEME || true
 
+# Example: force PulseAudio/Wine to target a non-default sink (uncomment and edit)
+# export FLEXSINK="alsa_output.usb-UC_MIC_ATR2USB-00.analog-stereo"
+# export PULSE_SINK="$FLEXSINK"
+
 SCRIPT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 BASE_DIR=$(cd -- "$SCRIPT_DIR/.." && pwd -P)
 DEFAULT_WINEPREFIX="$BASE_DIR/wineprefix"


### PR DESCRIPTION
## Summary
- add a commented PulseAudio sink override example to the FlexTalk control panel helper script
- document how to point the control panel at a non-default sink when the default device is a null output

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b7c2963388333818ea4bda1cf3aff)