### PR TITLE
Add newline after SSN command prefix

### DIFF
--- a/scripts/winetricks/ssn_nettts_bridge.py
+++ b/scripts/winetricks/ssn_nettts_bridge.py
@@ -13,8 +13,8 @@ NETTTS_HOST  = "127.0.0.1"
 NETTTS_PORT  = 5555          # change if your NetTTS listener uses a different port
 
 # Optional prefix tags for every spoken line
-# Example: PREFIX = "/rate 0 /pitch 0 "
-PREFIX       = "/rate 99 "
+# Example: PREFIX = "/rate 0\n/pitch 0\n"
+PREFIX       = "/rate 99\n"
 
 # Hard cap on message length so nobody can make you read a novel
 MAX_LEN      = 200
@@ -56,7 +56,7 @@ def send_to_nettts(text: str) -> None:
     if len(line) > MAX_LEN:
         line = line[:MAX_LEN] + "…"
 
-    payload = PREFIX + line + "\n"
+    payload = f"{PREFIX}{line}\n"
 
     try:
         with socket.create_connection((NETTTS_HOST, NETTTS_PORT), timeout=2) as s:


### PR DESCRIPTION
### Motivation
- Commands like `/rate` must be on their own line for NetTTS to treat them as commands, so the default prefix needs a trailing newline.
- The existing example showed space-separated commands which can concatenate with spoken text and prevent proper parsing.

### Description
- Updated the `PREFIX` example comment to demonstrate newline-separated commands (`"/rate 0\n/pitch 0\n"`).
- Changed the default `PREFIX` value to include a trailing newline (`"/rate 99\n"`).
- Constructed the outgoing payload using an f-string (`payload = f"{PREFIX}{line}\n"`) to ensure the prefix and message are concatenated with the newlines.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694809afe858833384ae4a67e7541932)