### PR TITLE
Apply keepalive to main TCP server connections

### DIFF
--- a/src/net_server.cpp
+++ b/src/net_server.cpp
@@ -178,6 +178,7 @@ static DWORD WINAPI server_thread(LPVOID){
         sockaddr_in cli; int clen=sizeof(cli);
         SOCKET s = accept(g_listen,(sockaddr*)&cli,&clen);
         if(s==INVALID_SOCKET) continue;
+        configure_keepalive(s);
         dprintf("[net] client connected");
 
         std::string buf; buf.reserve(1024);


### PR DESCRIPTION
## Summary
- enable TCP keepalive on accepted sockets in the main TCP server to match the status server behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cebfeaac8833388bbdbf035c30419)